### PR TITLE
Expose external GPIO input injection and ADC set via HMP monitor comm…

### DIFF
--- a/hmp-commands.hx
+++ b/hmp-commands.hx
@@ -5,6 +5,31 @@ HXCOMM which specify the name, behaviour and help text for HMP commands.
 HXCOMM Text between SRST and ERST is rST format documentation.
 HXCOMM HXCOMM can be used for comments, discarded from both rST and C.
 
+    {
+        .name       = "esp32_set_gpio_input",
+        .args_type  = "gpio:i,value:i",
+        .params     = "gpio value",
+        .help       = "physicalsim: drive an external level onto an esp32 GPIO input line",
+        .cmd        = hmp_esp32_set_gpio_input,
+    },
+
+SRST
+``esp32_set_gpio_input`` *gpio* *value*
+  physicalsim addition: sets GPIO *gpio*'s external input level to *value* (0/1).
+ERST
+
+    {
+        .name       = "esp32_set_adc",
+        .args_type  = "channel:i,value:i",
+        .params     = "channel value",
+        .help       = "physicalsim: set an esp32 ADC1 channel's raw SAR reading",
+        .cmd        = hmp_esp32_set_adc,
+    },
+
+SRST
+``esp32_set_adc`` *channel* *value*
+  physicalsim addition: sets ADC1 channel *channel*'s raw (0-4095) SAR reading to *value*.
+ERST
 
     {
         .name       = "help|?",

--- a/hw/xtensa/esp32_picsimlab.c
+++ b/hw/xtensa/esp32_picsimlab.c
@@ -37,6 +37,8 @@
 #include "exec/exec-all.h"
 #include "net/net.h"
 #include "elf.h"
+#include "monitor/hmp.h"
+#include "qapi/qmp/qdict.h"
 
 #ifdef _WIN32
 #include "chardev/char-win.h"
@@ -245,8 +247,44 @@ void qemu_picsimlab_set_pin(int pin,int value)
 
 void qemu_picsimlab_set_apin(int chn,int value)
 {
-   Esp32SensState *s = ESP32_SENS(&(global_s->sens));  
+   Esp32SensState *s = ESP32_SENS(&(global_s->sens));
    s->ADC_values[chn] = value;
+}
+
+/*
+ * physicalsim additions: two HMP monitor commands reachable over the
+ * plain GDB RSP connection any external process already has open (via
+ * the "monitor" / qRcmd extension - see gdbstub/system.c's
+ * gdb_handle_query_rcmd()), for a process that spawned qemu-system-xtensa
+ * as a subprocess (not linked in as a library the way PICSimLab itself
+ * is) and so can't call qemu_picsimlab_set_pin()/set_apin() directly.
+ *
+ * esp32_set_gpio_input doesn't reuse qemu_picsimlab_set_pin() above -
+ * that one drives pin_irq[], which is only wired up when a PICSimLab
+ * pinmap was registered via qemu_picsimlab_register_callbacks() (see
+ * esp32_soc_realize() below, "if(pinmap)"), which never happens for a
+ * plain command-line-spawned qemu-system-xtensa. This resolves the GPIO
+ * device's own named "in" line directly through global_s instead, with
+ * no pinmap dependency at all.
+ */
+void esp32_set_gpio_input(int gpio, int value)
+{
+   if (!global_s) return;
+   qemu_set_irq(qdev_get_gpio_in_named(DEVICE(&global_s->gpio), ESP32_GPIOS_IN, gpio), value);
+}
+
+void hmp_esp32_set_gpio_input(Monitor *mon, const QDict *qdict)
+{
+   int gpio = qdict_get_int(qdict, "gpio");
+   int value = qdict_get_int(qdict, "value");
+   esp32_set_gpio_input(gpio, value);
+}
+
+void hmp_esp32_set_adc(Monitor *mon, const QDict *qdict)
+{
+   int channel = qdict_get_int(qdict, "channel");
+   int value = qdict_get_int(qdict, "value");
+   qemu_picsimlab_set_apin(channel, value);
 }
 
 int qemu_picsimlab_flash_dump( int64_t offset, void *buf, int bytes)

--- a/include/monitor/hmp.h
+++ b/include/monitor/hmp.h
@@ -179,4 +179,8 @@ void hmp_info_mtree(Monitor *mon, const QDict *qdict);
 void hmp_info_cryptodev(Monitor *mon, const QDict *qdict);
 void hmp_dumpdtb(Monitor *mon, const QDict *qdict);
 
+/* physicalsim additions - hw/xtensa/esp32_picsimlab.c */
+void hmp_esp32_set_gpio_input(Monitor *mon, const QDict *qdict);
+void hmp_esp32_set_adc(Monitor *mon, const QDict *qdict);
+
 #endif

--- a/scripts/symlink-install-tree.py
+++ b/scripts/symlink-install-tree.py
@@ -14,23 +14,29 @@ def destdir_join(d1: str, d2: str) -> str:
     # c:\destdir + c:\prefix must produce c:\destdir\prefix
     return str(PurePath(d1, *PurePath(d2).parts[1:]))
 
-introspect = os.environ.get('MESONINTROSPECT')
-out = subprocess.run([*shlex.split(introspect), '--installed'],
-                     stdout=subprocess.PIPE, check=True).stdout
-for source, dest in json.loads(out).items():
-    bundle_dest = destdir_join('qemu-bundle', dest)
-    path = os.path.dirname(bundle_dest)
-    try:
+# physicalsim build fix: this whole script only builds a convenience
+# "qemu-bundle" symlink tree for QEMU's own test suite (never read by
+# `ninja install`'s real output) - on this Windows/meson combination it
+# can't complete (MESONINTROSPECT resolves to a bare "meson" entry-point
+# script subprocess.run() can't exec directly, and even past that,
+# os.symlink() needs Developer Mode/Administrator on Windows), so the
+# whole thing is best-effort: skip on any failure rather than fail the
+# entire configure over a step nothing downstream depends on.
+try:
+    introspect = os.environ.get('MESONINTROSPECT')
+    if not introspect:
+        raise RuntimeError('MESONINTROSPECT not set')
+    out = subprocess.run([*shlex.split(introspect), '--installed'],
+                         stdout=subprocess.PIPE, check=True).stdout
+    for source, dest in json.loads(out).items():
+        bundle_dest = destdir_join('qemu-bundle', dest)
+        path = os.path.dirname(bundle_dest)
         os.makedirs(path, exist_ok=True)
-    except BaseException as e:
-        print(f'error making directory {path}', file=sys.stderr)
-        raise e
-    try:
-        os.symlink(source, bundle_dest)
-    except BaseException as e:
-        if not isinstance(e, OSError) or e.errno != errno.EEXIST:
-            if os.name == 'nt':
-                print('Please enable Developer Mode to support soft link '
-                      'without Administrator permission')
-            print(f'error making symbolic link {dest}', file=sys.stderr)
-            raise e
+        try:
+            os.symlink(source, bundle_dest)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+except BaseException as e:
+    print(f'symlink-install-tree.py: skipping ({e})', file=sys.stderr)
+sys.exit(0)


### PR DESCRIPTION
…ands

Adds two new HMP monitor commands - esp32_set_gpio_input and esp32_set_adc - reachable over the plain GDB RSP connection any external process already has open via the "monitor"/qRcmd extension, for a process that spawns qemu-system-xtensa as a subprocess rather than linking libqemu-esp32 in the way PICSimLab itself does (so it can't call qemu_picsimlab_set_pin()/set_apin() directly).

esp32_set_gpio_input resolves the GPIO device's own named "in" line through global_s directly, independent of the PICSimLab pinmap (qemu_picsimlab_set_pin's own pin_irq[] array is only wired up when a pinmap was registered via qemu_picsimlab_register_callbacks(), which never happens for a plain command-line-spawned instance). esp32_set_adc reuses the existing qemu_picsimlab_set_apin() path, which has no such dependency.

Verified end-to-end against a real ESP-IDF sketch (reads GPIO5, mirrors it onto GPIO18): injecting esp32_set_gpio_input over GDB RSP while the guest is running is observed by the guest's own gpio_get_level() call.

Also fixes scripts/symlink-install-tree.py, which failed configure outright on this Windows/meson combination (MESONINTROSPECT resolving to a bare "meson" entry-point script subprocess.run() can't exec directly, and os.symlink() needing Developer Mode/Administrator on Windows even past that) - the script only builds a convenience "qemu-bundle" symlink tree for the test suite, so it now skips on any failure instead of failing the whole configure.